### PR TITLE
Implement caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Evan Trujillo",
   "license": "ISC",
   "devDependencies": {
+    "@types/apicache": "^1.6.6",
     "@types/body-parser": "^1.19.5",
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.17",
@@ -36,6 +37,7 @@
     "ts-node": "^10.9.2"
   },
   "dependencies": {
+    "apicache": "^1.6.3",
     "body-parser": "^1.20.2",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  apicache:
+    specifier: ^1.6.3
+    version: 1.6.3
   body-parser:
     specifier: ^1.20.2
     version: 1.20.2
@@ -22,6 +25,9 @@ dependencies:
     version: 9.0.1
 
 devDependencies:
+  '@types/apicache':
+    specifier: ^1.6.6
+    version: 1.6.6
   '@types/body-parser':
     specifier: ^1.19.5
     version: 1.19.5
@@ -180,6 +186,13 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
+  /@types/apicache@1.6.6:
+    resolution: {integrity: sha512-RLeWpWG8QmXS2DshAMIm3HAtmUivFTSzdppppQgvNvbPYfi4871Ec4cXGySAlC9qqmciAZSVCWZPKAwNKwGATA==}
+    dependencies:
+      '@types/express': 4.17.21
+      '@types/redis': 2.8.32
+    dev: true
+
   /@types/body-parser@1.19.5:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
@@ -239,6 +252,12 @@ packages:
 
   /@types/range-parser@1.2.7:
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+    dev: true
+
+  /@types/redis@2.8.32:
+    resolution: {integrity: sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==}
+    dependencies:
+      '@types/node': 20.11.17
     dev: true
 
   /@types/semver@7.5.6:
@@ -459,6 +478,11 @@ packages:
       normalize-path: 3.0.0
       picomatch: 2.3.1
     dev: true
+
+  /apicache@1.6.3:
+    resolution: {integrity: sha512-jS3VfUFpQ9BesFQZcdd1vVYg3ZsO2kGPmTJHqycIYPAQs54r74CRiyj8DuzJpwzLwIfCBYzh4dy9Jt8xYbo27w==}
+    engines: {node: '>=8'}
+    dev: false
 
   /arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import express, { Express } from "express";
+import apicache from "apicache";
 import { v1workoutRouter } from "./v1/routes/workoutRoutes";
 
 const app: Express = express();
+const cache = apicache.middleware;
 const PORT = process.env.PORT || 3000;
 
-app.use("/api/v1/workouts", v1workoutRouter);
+app.use("/api/v1/workouts", cache("2 minutes"), v1workoutRouter);
 
 app.listen(PORT, () => {
   console.log(`API is listening on port ${PORT}`);


### PR DESCRIPTION
This PR introduces caching to all routes in the API. By using caching we can improve performance of the backend and reduce the need to request data directly from the database. Most likely we will be dealing with larger sets of data as the application matures and more users sign up. Caching will be ideal when requesting large amounts of data (such as all workouts) as the heavy lifting from the database and the time it takes to retrieve the data will be reduced.

[apicache](https://github.com/kwhitley/apicache) - will be the middleware used for caching because of its simple usage. 