### PR TITLE
Records CRUD operations

### DIFF
--- a/src/database/Record.ts
+++ b/src/database/Record.ts
@@ -1,5 +1,5 @@
 import { RecordFilterParams } from "../types";
-import { StatusError } from "./Workout";
+import { StatusError } from "../types";
 import db from "./db.json";
 
 type Record = {

--- a/src/database/Record.ts
+++ b/src/database/Record.ts
@@ -1,3 +1,4 @@
+import { RecordFilterParams } from "../types";
 import { StatusError } from "./Workout";
 import db from "./db.json";
 
@@ -26,4 +27,19 @@ export const getRecordForWorkout = (workoutId: string) => {
     throw statusError;
   }
   return results;
+};
+
+export const getAllRecords = (filterParams: RecordFilterParams) => {
+  try {
+    if (filterParams.length) {
+      return records.filter(
+        (_, index) => filterParams.length && index < filterParams.length
+      );
+    }
+    return records;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw { status: 500, message: error?.message || error };
+    }
+  }
 };

--- a/src/database/Record.ts
+++ b/src/database/Record.ts
@@ -1,15 +1,6 @@
-import { RecordFilterParams } from "../types";
+import { RecordFilterParams, Records } from "../types";
 import { StatusError } from "../types";
 import db from "./db.json";
-
-type Record = {
-  id: string;
-  workout: string;
-  record: string;
-  createdAt: string;
-};
-
-type Records = Record[];
 
 const records = db.records as Records;
 export const getRecordForWorkout = (workoutId: string) => {
@@ -55,4 +46,23 @@ export const getAllRecords = (filterParams: RecordFilterParams) => {
       throw { status: 500, message: error?.message || error };
     }
   }
+};
+
+export const getExistingRecord = (recordId: string) => {
+  let result: Records = [];
+  try {
+    result = records.filter((record) => record.id === recordId);
+  } catch (error) {
+    if (error instanceof Error) {
+      throw { status: 500, message: error?.message || error };
+    }
+  }
+  if (result.length === 0) {
+    const statusError = new StatusError();
+    statusError.status = 404;
+    statusError.message = `Record with id ${recordId} does not exist.`;
+    throw statusError;
+  }
+  const [record] = result;
+  return record;
 };

--- a/src/database/Record.ts
+++ b/src/database/Record.ts
@@ -6,6 +6,7 @@ type Record = {
   id: string;
   workout: string;
   record: string;
+  createdAt: string;
 };
 
 type Records = Record[];
@@ -35,6 +36,18 @@ export const getAllRecords = (filterParams: RecordFilterParams) => {
       return records.filter(
         (_, index) => filterParams.length && index < filterParams.length
       );
+    } else if (filterParams.sort) {
+      return records.toSorted((recordA, recordB) => {
+        if (recordA.createdAt && recordB.createdAt) {
+          const dateA = new Date(recordA.createdAt);
+          const dateB = new Date(recordB.createdAt);
+          if (filterParams.sort === "-createdat") {
+            return dateB.getTime() - dateA.getTime();
+          }
+          return dateA.getTime() - dateB.getTime();
+        }
+        return -1;
+      });
     }
     return records;
   } catch (error) {

--- a/src/database/Record.ts
+++ b/src/database/Record.ts
@@ -1,8 +1,10 @@
 import { RecordFilterParams, Records } from "../types";
-import { StatusError } from "../types";
+import { StatusError, Record } from "../types";
 import db from "./db.json";
+import { saveToDatabase } from "./utils";
 
 const records = db.records as Records;
+
 export const getRecordForWorkout = (workoutId: string) => {
   let results: Records = [];
   try {
@@ -66,3 +68,26 @@ export const getExistingRecord = (recordId: string) => {
   const [record] = result;
   return record;
 };
+
+export const createNewRecord = (newRecord: Record) => {
+  console.log(newRecord);
+  const isAlreadyAdded =
+    records.findIndex((record) => record.id === newRecord.id) > -1;
+  console.log(isAlreadyAdded);
+  if (isAlreadyAdded) {
+    const statusError = new StatusError();
+    statusError.status = 400;
+    statusError.message = `Record with the id ${newRecord.id} already exists.`;
+    throw statusError;
+  }
+  try {
+    records.push(newRecord);
+    saveToDatabase(records);
+    return newRecord;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw { status: 500, message: error?.message || error };
+    }
+  }
+};
+//TODO Fix issue with inserting a new record that is already in the DB

--- a/src/database/Workout.ts
+++ b/src/database/Workout.ts
@@ -1,10 +1,6 @@
 import db from "./db.json";
 import { saveToDatabase, newDate } from "./utils";
-import { WorkoutFilterParams, Workout, Workouts } from "../types";
-
-export class StatusError extends Error {
-  status: number | undefined;
-}
+import { WorkoutFilterParams, Workout, Workouts, StatusError } from "../types";
 
 const workouts = db.workouts as Workouts;
 

--- a/src/database/Workout.ts
+++ b/src/database/Workout.ts
@@ -1,6 +1,6 @@
 import db from "./db.json";
 import { saveToDatabase, newDate } from "./utils";
-import { FilterParams, Workout, Workouts } from "../types";
+import { WorkoutFilterParams, Workout, Workouts } from "../types";
 
 export class StatusError extends Error {
   status: number | undefined;
@@ -12,7 +12,7 @@ function filterWorkoutById(workoutId: string) {
   return workouts.filter((workout) => workout.id === workoutId);
 }
 
-export const getAllWorkouts = (filterParams: FilterParams) => {
+export const getAllWorkouts = (filterParams: WorkoutFilterParams) => {
   try {
     if (filterParams.mode) {
       return workouts.filter((workout) => {

--- a/src/database/db.json
+++ b/src/database/db.json
@@ -182,22 +182,26 @@
     {
       "id": "ad75d475-ac57-44f4-a02a-8f6def58ff56",
       "workout": "4a3d9aaa-608c-49a7-a004-66305ad4ab50",
-      "record": "160 reps"
+      "record": "160 reps",
+      "createdAt": "3/25/2023, 2:43:02 PM"
     },
     {
       "id": "0bff586f-2017-4526-9e52-fe3ea46d55ab",
       "workout": "d8be2362-7b68-4ea4-a1f6-03f8bc4eede7",
-      "record": "7:23 minutes"
+      "record": "7:23 minutes",
+      "createdAt": "5/10/2023, 1:52:26 PM"
     },
     {
       "id": "365cc0bb-ba8f-41d3-bf82-83d041d38b82",
       "workout": "a24d2618-01d1-4682-9288-8de1343e53c7",
-      "record": "358 reps"
+      "record": "358 reps",
+      "createdAt": "9/04/2022, 9:56:21 AM"
     },
     {
       "id": "62251cfe-fdb6-4fa6-9a2d-c21be93ac78d",
       "workout": "4a3d9aaa-608c-49a7-a004-66305ad4ab50",
-      "record": "145 reps"
+      "record": "145 reps",
+      "createdAt": "11/27/2023, 5:32:01 PM"
     }
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 import express, { Express } from "express";
 import apicache from "apicache";
 import { v1workoutRouter } from "./v1/routes/workoutRoutes";
+import { v1recordRouter } from "./v1/routes/recordsRoutes";
 
 const app: Express = express();
 const cache = apicache.middleware;
 const PORT = process.env.PORT || 3000;
 
 app.use("/api/v1/workouts", cache("2 minutes"), v1workoutRouter);
+app.use("/api/v1/records", cache("2 minutes"), v1recordRouter);
 
 app.listen(PORT, () => {
   console.log(`API is listening on port ${PORT}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,7 @@
+export class StatusError extends Error {
+  status: number | undefined;
+}
+
 type Sort = "createdat" | "-createdat";
 
 export type WorkoutFilterParams = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,3 +29,12 @@ export type Workout = {
 };
 
 export type Workouts = Workout[];
+
+export type Record = {
+  id?: string;
+  workout?: string;
+  record?: string;
+  createdAt?: string;
+};
+
+export type Records = Record[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,15 @@
-export type FilterParams = {
+type Sort = "createdat" | "-createdat";
+
+export type WorkoutFilterParams = {
   mode?: string;
   equipment?: string;
   length?: number;
-  sort?: "createdat" | "-createdat";
+  sort?: Sort;
+};
+
+export type RecordFilterParams = {
+  length?: number;
+  sort?: Sort;
 };
 
 export type Workout = {

--- a/src/v1/controllers/recordsController.ts
+++ b/src/v1/controllers/recordsController.ts
@@ -1,4 +1,5 @@
 import {
+  createNewRecordService,
   getAllRecordsService,
   getExistingRecordService,
   getRecordForWorkoutService,
@@ -6,7 +7,7 @@ import {
 import { Request, Response } from "express";
 import { StatusError } from "../../types";
 import { validationResult } from "express-validator";
-import { RecordFilterParams } from "../../types";
+import { RecordFilterParams, Record } from "../../types";
 
 export const getRecordForWorkoutController = (req: Request, res: Response) => {
   const result = validationResult(req);
@@ -60,4 +61,31 @@ export const getExistingRecordController = (req: Request, res: Response) => {
     }
   }
   return res.status(400).send({ errors: result.array() });
+};
+
+export const createNewRecordController = (req: Request, res: Response) => {
+  const result = validationResult(req);
+  if (result.isEmpty()) {
+    const {
+      body: { id, workout, record },
+    } = req;
+
+    const newRecord: Record = {
+      id,
+      workout,
+      record,
+    };
+
+    try {
+      const createNewRecord = createNewRecordService(newRecord);
+      return res.status(201).send(createNewRecord);
+    } catch (error) {
+      if (error instanceof StatusError) {
+        return res
+          .status(error?.status || 500)
+          .send({ status: "FAILED", error: error?.message || error });
+      }
+    }
+  }
+  return res.status(400).send({ error: result.array() });
 };

--- a/src/v1/controllers/recordsController.ts
+++ b/src/v1/controllers/recordsController.ts
@@ -1,7 +1,11 @@
-import { getRecordForWorkoutService } from "../services/recordsService";
+import {
+  getAllRecordsService,
+  getRecordForWorkoutService,
+} from "../services/recordsService";
 import { Request, Response } from "express";
 import { StatusError } from "../../database/Workout";
 import { validationResult } from "express-validator";
+import { RecordFilterParams } from "../../types";
 
 export const getRecordForWorkoutController = (req: Request, res: Response) => {
   const result = validationResult(req);
@@ -21,4 +25,18 @@ export const getRecordForWorkoutController = (req: Request, res: Response) => {
     }
   }
   return res.status(400).send({ errors: result.array() });
+};
+
+export const getAllRecordsController = (req: Request, res: Response) => {
+  const { length, sort } = req.query as RecordFilterParams;
+  try {
+    const allRecords = getAllRecordsService({ length, sort });
+    return res.status(200).send(allRecords);
+  } catch (error) {
+    if (error instanceof StatusError) {
+      return res
+        .status(error?.status || 500)
+        .send({ status: "FAILED", error: error?.message || error });
+    }
+  }
 };

--- a/src/v1/controllers/recordsController.ts
+++ b/src/v1/controllers/recordsController.ts
@@ -3,7 +3,7 @@ import {
   getRecordForWorkoutService,
 } from "../services/recordsService";
 import { Request, Response } from "express";
-import { StatusError } from "../../database/Workout";
+import { StatusError } from "../../types";
 import { validationResult } from "express-validator";
 import { RecordFilterParams } from "../../types";
 

--- a/src/v1/controllers/recordsController.ts
+++ b/src/v1/controllers/recordsController.ts
@@ -1,5 +1,6 @@
 import {
   getAllRecordsService,
+  getExistingRecordService,
   getRecordForWorkoutService,
 } from "../services/recordsService";
 import { Request, Response } from "express";
@@ -39,4 +40,24 @@ export const getAllRecordsController = (req: Request, res: Response) => {
         .send({ status: "FAILED", error: error?.message || error });
     }
   }
+};
+
+export const getExistingRecordController = (req: Request, res: Response) => {
+  const result = validationResult(req);
+  if (result.isEmpty()) {
+    const {
+      params: { recordId },
+    } = req;
+    try {
+      const existingRecord = getExistingRecordService(recordId);
+      return res.status(200).send(existingRecord);
+    } catch (error) {
+      if (error instanceof StatusError) {
+        return res
+          .status(error?.status || 500)
+          .send({ status: "FAILED", error: error?.message || error });
+      }
+    }
+  }
+  return res.status(400).send({ errors: result.array() });
 };

--- a/src/v1/controllers/workoutController.ts
+++ b/src/v1/controllers/workoutController.ts
@@ -7,7 +7,7 @@ import {
 } from "../services/workoutService";
 import { Request, Response } from "express";
 import { validationResult } from "express-validator";
-import { StatusError } from "../../database/Workout";
+import { StatusError } from "../../types";
 import { WorkoutFilterParams, Workout } from "../../types";
 
 export const getAllWorkouts = (req: Request, res: Response) => {

--- a/src/v1/controllers/workoutController.ts
+++ b/src/v1/controllers/workoutController.ts
@@ -8,10 +8,10 @@ import {
 import { Request, Response } from "express";
 import { validationResult } from "express-validator";
 import { StatusError } from "../../database/Workout";
-import { FilterParams, Workout } from "../../types";
+import { WorkoutFilterParams, Workout } from "../../types";
 
 export const getAllWorkouts = (req: Request, res: Response) => {
-  const { mode, equipment, length, sort } = req.query as FilterParams;
+  const { mode, equipment, length, sort } = req.query as WorkoutFilterParams;
   try {
     const allWorkouts = getAllWorkoutsService({
       mode,

--- a/src/v1/routes/recordsRoutes.ts
+++ b/src/v1/routes/recordsRoutes.ts
@@ -1,8 +1,17 @@
 import express, { Router } from "express";
 import { jsonParser } from "../../database/utils";
 import { param, checkExact, body } from "express-validator";
-import { getAllRecordsController } from "../controllers/recordsController";
+import {
+  getAllRecordsController,
+  getExistingRecordController,
+} from "../controllers/recordsController";
 
 export const v1recordRouter: Router = express.Router();
 
 v1recordRouter.get("/", getAllRecordsController);
+
+v1recordRouter.get(
+  "/:recordId",
+  param("recordId").isUUID(4),
+  getExistingRecordController
+);

--- a/src/v1/routes/recordsRoutes.ts
+++ b/src/v1/routes/recordsRoutes.ts
@@ -2,6 +2,7 @@ import express, { Router } from "express";
 import { jsonParser } from "../../database/utils";
 import { param, checkExact, body } from "express-validator";
 import {
+  createNewRecordController,
   getAllRecordsController,
   getExistingRecordController,
 } from "../controllers/recordsController";
@@ -14,4 +15,17 @@ v1recordRouter.get(
   "/:recordId",
   param("recordId").isUUID(4),
   getExistingRecordController
+);
+
+v1recordRouter.post(
+  "/",
+  jsonParser,
+  body(["id", "workout", "record"])
+    .notEmpty()
+    .escape()
+    .withMessage(
+      "The following key (path) is missing or is empty in request body."
+    ),
+  checkExact(),
+  createNewRecordController
 );

--- a/src/v1/routes/recordsRoutes.ts
+++ b/src/v1/routes/recordsRoutes.ts
@@ -1,0 +1,8 @@
+import express, { Router } from "express";
+import { jsonParser } from "../../database/utils";
+import { param, checkExact, body } from "express-validator";
+import { getAllRecordsController } from "../controllers/recordsController";
+
+export const v1recordRouter: Router = express.Router();
+
+v1recordRouter.get("/", getAllRecordsController);

--- a/src/v1/services/recordsService.ts
+++ b/src/v1/services/recordsService.ts
@@ -1,4 +1,8 @@
-import { getAllRecords, getRecordForWorkout } from "../../database/Record";
+import {
+  getAllRecords,
+  getExistingRecord,
+  getRecordForWorkout,
+} from "../../database/Record";
 import { WorkoutFilterParams } from "../../types";
 
 export const getRecordForWorkoutService = (workoutId: string) => {
@@ -15,6 +19,16 @@ export const getAllRecordsService = (filterParams: WorkoutFilterParams) => {
   try {
     const allRecords = getAllRecords(filterParams);
     return allRecords;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
+export const getExistingRecordService = (recordId: string) => {
+  try {
+    const existingRecord = getExistingRecord(recordId);
+    return existingRecord;
   } catch (error) {
     console.log(error);
     throw error;

--- a/src/v1/services/recordsService.ts
+++ b/src/v1/services/recordsService.ts
@@ -2,8 +2,9 @@ import {
   getAllRecords,
   getExistingRecord,
   getRecordForWorkout,
+  createNewRecord,
 } from "../../database/Record";
-import { WorkoutFilterParams } from "../../types";
+import { WorkoutFilterParams, Record } from "../../types";
 
 export const getRecordForWorkoutService = (workoutId: string) => {
   try {
@@ -29,6 +30,16 @@ export const getExistingRecordService = (recordId: string) => {
   try {
     const existingRecord = getExistingRecord(recordId);
     return existingRecord;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
+export const createNewRecordService = (record: Record) => {
+  try {
+    const newRecord = createNewRecord(record);
+    return newRecord;
   } catch (error) {
     console.log(error);
     throw error;

--- a/src/v1/services/recordsService.ts
+++ b/src/v1/services/recordsService.ts
@@ -1,9 +1,20 @@
-import { getRecordForWorkout } from "../../database/Record";
+import { getAllRecords, getRecordForWorkout } from "../../database/Record";
+import { WorkoutFilterParams } from "../../types";
 
 export const getRecordForWorkoutService = (workoutId: string) => {
   try {
     const recordForWorkout = getRecordForWorkout(workoutId);
     return recordForWorkout;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
+export const getAllRecordsService = (filterParams: WorkoutFilterParams) => {
+  try {
+    const allRecords = getAllRecords(filterParams);
+    return allRecords;
   } catch (error) {
     console.log(error);
     throw error;

--- a/src/v1/services/workoutService.ts
+++ b/src/v1/services/workoutService.ts
@@ -5,11 +5,11 @@ import {
   updateExistingWorkout,
   deleteExistingWorkout,
 } from "../../database/Workout";
-import { FilterParams, Workout } from "../../types";
+import { WorkoutFilterParams, Workout } from "../../types";
 import { v4 as uuidv4 } from "uuid";
 import { newDate } from "../../database/utils";
 
-export const getAllWorkoutsService = (filterParams: FilterParams) => {
+export const getAllWorkoutsService = (filterParams: WorkoutFilterParams) => {
   try {
     const allWorkouts = getAllWorkouts(filterParams);
     return allWorkouts;


### PR DESCRIPTION
This PR introduces CRUD operations for the records table. Although not needed now it is highly likely that we will need operations to handle records in some sort of admin panel. This introduction of operations will prepare the app for future implementations.

new routes:

GET - all records
```
/api/v1/records
```

GET - one record by id
```
/api/v1/records/:recordId
```

POST - create a new record object
```
/api/v1/records
```

DELETE - delete an existing record
```
/api/v1/records/recordId
```

